### PR TITLE
fix/client-timeout-redirect-issue

### DIFF
--- a/src/api/alitaApi.js
+++ b/src/api/alitaApi.js
@@ -8,14 +8,15 @@ export const alitaApi = createApi({
   baseQuery: fetchBaseQuery({
     baseUrl: VITE_SERVER_URL,
     // mode: "cors",
-    fetchFn: async (request) => {
-      const response = await fetch(request);
+    fetchFn: async (...args) => {
+      const response = await fetch(...args);
       if (response.redirected) {
-        const redirectUrl = response.url;
-        window.location.href = redirectUrl
-        return { redirectUrl };
+        const redirectUrl = new URL(response.url);
+        redirectUrl.searchParams.delete('target_to');
+        const modifiedUrlString = redirectUrl.toString();
+        window.location.href = modifiedUrlString;
+        return { modifiedUrlString };
       }
-
       return response;
     },
     prepareHeaders: (headers) => {


### PR DESCRIPTION
Current redirect_to is the api url that needs auth, should not redirect user to this link. Hence remove it.