### PR TITLE
fix/version-nav-miss-routes

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -74,35 +74,54 @@ const ProtectedRoutes = () => {
 
   const routes = [
     { path: RouteDefinitions.Profile, element: <UserProfile /> },
+    { path: RouteDefinitions.Settings, element: <Settings /> },
+  
+    /* prompt detail routes start*/
+    { path: RouteDefinitions.CreatePrompt, element: <CreatePrompt /> },
+
+    // my library prompt
+    { path: RouteDefinitions.EditPrompt, element: <EditPrompt /> },
+  
+    // moderation prompt:
+    { path: RouteDefinitions.ModerationSpacePrompt, element: <EditPrompt />, requiredPermissions: PERMISSION_GROUPS.moderation },
+  
+    // public prompt prompt
+    { path: RouteDefinitions.ViewPrompt, element: <EditPrompt /> },
+  
+    // my library collection prompt 
+    { path: RouteDefinitions.MyLibraryCollectionPromptDetail, element: <EditPrompt /> },
+  
+    // public collection prompt 
+    { path: RouteDefinitions.CollectionPromptDetail, element: <EditPrompt /> },
+  
+    // user public prompt
+    { path: RouteDefinitions.UserPublicPrompts, element: <EditPrompt /> },
+
+    // user public collection prompt
+    { path: RouteDefinitions.UserPublicCollectionPromptDetail, element: <EditPrompt /> },
+    /* prompt detail routes end*/
+  
+    // left drawer menu pages
     { path: RouteDefinitions.Prompts, element: <Prompts /> },
     { path: RouteDefinitions.PromptsWithTab, element: <Prompts /> },
-    { path: RouteDefinitions.MyLibrary, element: < MyLibrary /> },
-    { path: RouteDefinitions.MyLibraryWithTab, element: < MyLibrary /> },
-    { path: RouteDefinitions.UserPublic, element: < MyLibrary /> },
-    { path: RouteDefinitions.UserPublicWithTab, element: < MyLibrary /> },
-    { path: RouteDefinitions.UserPublicCollectionDetail, element: <CollectionDetail /> },
-    { path: RouteDefinitions.UserPublicCollectionPromptDetail, element: <EditPrompt /> },
-    { path: RouteDefinitions.UserPublicPrompts, element: <EditPrompt /> },
-    { path: RouteDefinitions.UserPublicPromptsVersionDetail, element: <EditPrompt /> },
     { path: RouteDefinitions.Collections, element: <Collections /> },
     { path: RouteDefinitions.CollectionsWithTab, element: <Collections /> },
+    { path: RouteDefinitions.ModerationSpace, element: <ModerationSpace />, requiredPermissions: PERMISSION_GROUPS.moderation },
+    { path: RouteDefinitions.MyLibrary, element: < MyLibrary /> },
+    { path: RouteDefinitions.MyLibraryWithTab, element: < MyLibrary /> },
+  
+    // user public page
+    { path: RouteDefinitions.UserPublic, element: < MyLibrary /> },
+    { path: RouteDefinitions.UserPublicWithTab, element: < MyLibrary /> },
+  
+    // Collection detail routes
     { path: RouteDefinitions.CreateCollection, element: <CreateCollection /> },
     { path: RouteDefinitions.EditCollection, element: <EditCollection /> },
     { path: RouteDefinitions.CollectionDetail, element: <CollectionDetail /> },
-    { path: RouteDefinitions.CollectionPromptDetail, element: <EditPrompt /> },
     { path: RouteDefinitions.MyLibraryCollectionDetail, element: <CollectionDetail /> },
-    { path: RouteDefinitions.CreatePrompt, element: <CreatePrompt /> },
-    { path: RouteDefinitions.ViewPrompt, element: <EditPrompt /> },
-    { path: RouteDefinitions.ViewPromptVersion, element: <EditPrompt /> },
-    { path: RouteDefinitions.EditPrompt, element: <EditPrompt /> },
-    { path: RouteDefinitions.EditPromptVersion, element: <EditPrompt /> },
-    { path: RouteDefinitions.MyLibraryCollectionPromptDetail, element: <EditPrompt /> },
-    { path: RouteDefinitions.MyLibraryCollectionPromptVersionDetail, element: <EditPrompt /> },
-    { path: RouteDefinitions.Settings, element: <Settings /> },
-    { path: RouteDefinitions.ModerationSpace, element: <ModerationSpace />, requiredPermissions: PERMISSION_GROUPS.moderation },
-    { path: RouteDefinitions.ModerationSpacePrompt, element: <EditPrompt />, requiredPermissions: PERMISSION_GROUPS.moderation },
-    { path: RouteDefinitions.ModerationSpacePromptVersion, element: <EditPrompt />, requiredPermissions: PERMISSION_GROUPS.moderation },
+    { path: RouteDefinitions.UserPublicCollectionDetail, element: <CollectionDetail /> },
   ];
+
   return <Routes>
     <Route index element={<Navigate to={`${RouteDefinitions.Prompts}/${PromptsTabs[1]}`} replace />} />
     {
@@ -114,8 +133,9 @@ const ProtectedRoutes = () => {
             <ProtectedRoute requiredPermissions={requiredPermissions}>
               {element}
             </ProtectedRoute>
-          }
-        />
+          }>
+            { path.endsWith('/:promptId') && <Route path=':version' element={element} /> }
+        </Route>
       ))
     }
     <Route path="*" element={<Page404 />} />
@@ -126,7 +146,7 @@ const App = () => {
   const router = createBrowserRouter(
     createRoutesFromElements(
       <Route
-        path="/*"
+        path="/"
         element={
           <>
             <NavBar />

--- a/src/components/HeaderSplitButton.jsx
+++ b/src/components/HeaderSplitButton.jsx
@@ -29,7 +29,7 @@ const breadCrumbMap = {
 const StyledButtonGroup = styled(ButtonGroup)(({ theme }) => (`
     background: ${theme.palette.split.default};
     border-radius: 28px;
-    margin-right: 24px;
+    margin-right: 8px;
 `))
 
 const StyledDivider = styled(Divider)(({ theme }) => (`

--- a/src/routes.js
+++ b/src/routes.js
@@ -2,32 +2,32 @@ const RouteDefinitions = {
   Prompts: '/prompts',
   PromptsWithTab: '/prompts/:tab',
   ViewPrompt: '/prompts/:tab/:promptId',
-  ViewPromptVersion: '/prompts/:tab/:promptId/:version',
+
   Collections: '/collections',
   CollectionsWithTab: '/collections/:tab',
   CollectionDetail: '/collections/:tab/:collectionId',
   CollectionPromptDetail: '/collections/:tab/:collectionId/prompts/:promptId',
+
   DataSources: '/datasources',
+
   MyLibrary: '/my-library',
   MyLibraryWithTab: '/my-library/:tab',
   CreatePrompt: '/my-library/prompts/create',
+  EditPrompt: '/my-library/prompts/:promptId',
   CreateCollection: '/my-library/collections/create',        
   EditCollection: '/my-library/collections/edit/:collectionId',
-  EditPrompt: '/my-library/prompts/:promptId',
-  EditPromptVersion: '/my-library/prompts/:promptId/:version',
   MyLibraryCollectionDetail: '/my-library/collections/:collectionId',
   MyLibraryCollectionPromptDetail: '/my-library/collections/:collectionId/prompts/:promptId',
-  MyLibraryCollectionPromptVersionDetail: '/my-library/collections/:collectionId/prompts/:promptId/:version',
+
   ModerationSpace: '/moderation-space',
   ModerationSpacePrompt: '/moderation-space/prompts/:promptId',
-  ModerationSpacePromptVersion: '/moderation-space/prompts/:promptId/:version',
+
   UserPublic: '/user-public',
   UserPublicWithTab: '/user-public/:tab',
+  UserPublicPrompts: '/user-public/prompts/:promptId',
   UserPublicCollectionDetail: '/user-public/collections/:collectionId',
   UserPublicCollectionPromptDetail: '/user-public/collections/:collectionId/prompts/:promptId',
-  UserPublicCollectionPromptVersionDetail: '/user-public/collections/:collectionId/prompts/:promptId/:version',
-  UserPublicPrompts: '/user-public/prompts/:promptId',
-  UserPublicPromptsVersionDetail: '/user-public/prompts/:promptId/:version',
+  
   Profile: '/profile',
   Settings: '/settings',
 }


### PR DESCRIPTION
1. remove previous defined sub-path 
2. auto append "/:version" sub route for prompt detail routes
3. version nav set replace=true, use replace instead of building full pathname when nav