### PR TITLE
fix: the new version name is cached after canceling publishing

### DIFF
--- a/src/pages/EditPrompt/EditModeRunTabBarItems.jsx
+++ b/src/pages/EditPrompt/EditModeRunTabBarItems.jsx
@@ -138,6 +138,7 @@ export default function EditModeRunTabBarItems() {
   const onCancelShowInputVersion = useCallback(
     () => {
       setShowInputVersion(false);
+      setNewVersion('');
     },
     [],
   );


### PR DESCRIPTION
- fix: the new version name is cached after canceling publishing