### PR TITLE
fix/search-bar-issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5138,9 +5138,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.4.11",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.11.tgz",
-      "integrity": "sha512-ksNZJlkcU9b0lBwAGZGGaZHCMqHsc8OpgtoYhsQ4/I2v5cnpmmmqe5pM4nv/4Hn6G/2GhTdj0DhZh2e+Er1q5A==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.2.tgz",
+      "integrity": "sha512-tBCZBNSBbHQkaGyhGCDUGqeo2ph8Fstyp6FMSvTtsXeZSPpSMGlviAOav2hxVTqFcx8Hj/twtWKsMJXNY0xI8w==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.18.10",

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -19,6 +19,7 @@ DEV && console.debug('import.meta.env', import.meta.env)
 
 export const MIN_SEARCH_KEYWORD_LENGTH = 3;
 export const PAGE_SIZE = 20;
+export const SUGGESTION_PAGE_SIZE = 5;
 export const NAV_BAR_HEIGHT = '76px';
 export const PUBLIC_PROJECT_ID = VITE_PUBLIC_PROJECT_ID; // todo: rename it everywhere
 export const DEFAULT_MAX_TOKENS = 100;

--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -79,8 +79,9 @@ export default function SearchBar({
   const handleAddTag = useCallback((tag) => {
     if (!searchTags.some(item => item.id === tag.id)) {
       setSearchTags([...searchTags, tag]);
+      setSearchString('');
     }
-  }, [searchTags, setSearchTags]);
+  }, [searchTags, setSearchString, setSearchTags]);
 
   const handleDeleteTag = useCallback((tagIdToDelete) => () => {
     const restTags = searchTags.filter(({ id }) => id !== tagIdToDelete);

--- a/src/components/SearchBarComponents.jsx
+++ b/src/components/SearchBarComponents.jsx
@@ -1,6 +1,7 @@
 import { typographyVariants } from '@/MainTheme';
+import { SUGGESTION_PAGE_SIZE } from '@/common/constants';
 import { Box, CircularProgress, InputBase, List, ListItem, ListSubheader } from '@mui/material';
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import CancelIcon from './Icons/CancelIcon';
 import RemoveIcon from './Icons/RemoveIcon';
 import SearchIcon from './Icons/SearchIcon';
@@ -122,17 +123,19 @@ export const ListSection = ({
   total,
   renderItem,
   fetchMoreData,
-  emptyHint,
 }) => {
-  const pageSize = 5;
-  const [visibleCount, setVisibleCount] = useState(pageSize);
+  const [visibleCount, setVisibleCount] = useState(SUGGESTION_PAGE_SIZE);
   const handleShowMore = useCallback(() => {
-    const newVisibleCount = visibleCount + pageSize;
+    const newVisibleCount = visibleCount + SUGGESTION_PAGE_SIZE;
     setVisibleCount(newVisibleCount);
     if (data.length < newVisibleCount && data.length < total) {
       fetchMoreData();
     }
   }, [data.length, fetchMoreData, total, visibleCount]);
+
+  const remainedCount = useMemo(() => total - visibleCount, [total, visibleCount]);
+  const nextCount = useMemo(() => Math.min(SUGGESTION_PAGE_SIZE, remainedCount), [remainedCount]);
+
   return (
     <>
       <StyledListSubheader key={'sub-header-' + sectionTitle}>
@@ -147,13 +150,13 @@ export const ListSection = ({
         (data?.length > 0 ?
           <>
             {data.slice(0, visibleCount).map(renderItem)}
-            {total > visibleCount && (
+            {total > visibleCount && fetchMoreData && (
               <StyledListItem onClick={handleShowMore}>
-                {`...Show ${pageSize} More (${total - visibleCount})`}
+                {`...Show ${nextCount} More (${remainedCount})`}
               </StyledListItem>
             )}
           </>
-          : <StyledListItem disabled>{emptyHint || `No ${sectionTitle} Match`}</StyledListItem>
+          : <StyledListItem disabled>{`No ${sectionTitle} Match`}</StyledListItem>
         )
       }
     </>

--- a/src/components/SuggestionList.jsx
+++ b/src/components/SuggestionList.jsx
@@ -9,6 +9,8 @@ import { useCallback, useEffect, useState } from 'react';
 import { ListSection, StyledList, StyledListItem } from './SearchBarComponents';
 import { useSearchPromptNavigate } from './useCardNavigate';
 import useSearch from './useSearch';
+import useSearchBar from './useSearchBar';
+
 const useDebounce = (value, delay) => {
   const [debouncedValue, setDebouncedValue] = useState(value);
 
@@ -133,20 +135,31 @@ export default function SuggestionList({
       {name}
     </StyledListItem>
   }, [navToCollection]);
+
+  const {
+    isPublicPromptsPage,
+    isPublicCollectionsPage,
+  } = useSearchBar();
   return (
-    <StyledList>
+    <>
       {
-        showTopData ?
-          <ListSection
-            sectionTitle={AutoSuggestionTitles.TOP}
-            data={topResult}
-            total={topTotal}
-            isFetching={isFetchingTop}
-            renderItem={renderTopItem}
-            emptyHint='No Data'
-          />
-          :
-          <>
+        showTopData ? (
+          topResult?.length > 0
+            ?
+            <StyledList>
+              <ListSection
+                sectionTitle={AutoSuggestionTitles.TOP}
+                data={topResult}
+                total={topTotal}
+                isFetching={isFetchingTop}
+                renderItem={renderTopItem}
+              />
+              <ApiToast />
+            </StyledList>
+            :
+            <ApiToast />
+        ) : (
+          <StyledList>
             <ListSection
               sectionTitle={AutoSuggestionTitles.TAGS}
               data={tagResult}
@@ -155,25 +168,26 @@ export default function SuggestionList({
               renderItem={renderTagItem}
               fetchMoreData={fetchMoreData}
             />
-            <ListSection
+            {!isPublicCollectionsPage && <ListSection
               sectionTitle={AutoSuggestionTitles.PROMPTS}
               data={promptResult}
               total={promptTotal}
               isFetching={isFetching}
               renderItem={renderPromptItem}
               fetchMoreData={fetchMoreData}
-            />
-            <ListSection
+            />}
+            {!isPublicPromptsPage && <ListSection
               sectionTitle={AutoSuggestionTitles.COLLECTIONS}
               data={collectionResult}
               total={collectionTotal}
               isFetching={isFetching}
               renderItem={renderCollectionItem}
               fetchMoreData={fetchMoreData}
-            />
-          </>
+            />}
+            <ApiToast />
+          </StyledList>
+        )
       }
-      <ApiToast />
-    </StyledList>
+    </>
   )
 }

--- a/src/components/useSearch.jsx
+++ b/src/components/useSearch.jsx
@@ -1,5 +1,5 @@
 import { useLazyAutoSuggestQuery, useTopSearchQuery } from "@/api/search";
-import { AutoSuggestionTitles } from "@/common/constants";
+import { AutoSuggestionTitles, SUGGESTION_PAGE_SIZE } from "@/common/constants";
 import { useProjectId } from "@/pages/hooks";
 import { useEffect } from "react";
 import useToast from './useToast';
@@ -18,7 +18,7 @@ export default function useSearch(showTopData) {
   } = useTopSearchQuery({
     projectId,
     params: {
-      limit: 5,
+      limit: SUGGESTION_PAGE_SIZE,
       offset: 0
     }
   }, {


### PR DESCRIPTION
Fix:
1. Don't show prompts suggestion in public collection page; Don't show collection suggestion in public prompt page;
2. When user clicks to add tag, clear input text
3. Don't show The "Top Search Requests" popper at all when there is no data. 