### PR TITLE
fix: InputVersion dialog can't respond enter

### DIFF
--- a/src/pages/EditPrompt/Form/InputVersionDialog.jsx
+++ b/src/pages/EditPrompt/Form/InputVersionDialog.jsx
@@ -158,6 +158,7 @@ export default function InputVersionDialog({
 
   const { onKeyDown, onKeyUp, onCompositionStart, onCompositionEnd } = useCtrlEnterKeyEventsHandler(
     null,
+    null,
     onEnterPressed,
   );
   return (


### PR DESCRIPTION
- fix: InputVersion dialog can't respond enter