### PR TITLE
fix: scroll doesn't work in closed variables

### DIFF
--- a/src/components/StyledInputEnhancer.jsx
+++ b/src/components/StyledInputEnhancer.jsx
@@ -186,7 +186,7 @@ export default function StyledInputEnhancer(props) {
               : 'auto',
             overflowWrap: 'break-word',
             textOverflow: 'ellipsis',
-            overflow: 'hidden',
+            overflow: 'scroll',
             display: '-webkit-box',
             WebkitBoxOrient: 'vertical',
           },


### PR DESCRIPTION
- fix: scroll doesn't work in closed variables