### PR TITLE
fix: the prompt model temperature can not be cleared

### DIFF
--- a/src/pages/Prompts/Components/RunTab.jsx
+++ b/src/pages/Prompts/Components/RunTab.jsx
@@ -340,7 +340,7 @@ export default function RunTab({
         updateBody[PROMPT_PAYLOAD_KEY.modelName] = models[0];
       }
 
-      if (!temperature) {
+      if (temperature === null || temperature === undefined) {
         updateBody[PROMPT_PAYLOAD_KEY.temperature] =
           uidModelSettingsMap[integration_uid].temperature || DEFAULT_TEMPERATURE;
       }


### PR DESCRIPTION
- fix: the prompt model temperature can not be cleared