### PR TITLE
fix: change name of model into model_name in prompt predict body

### DIFF
--- a/src/components/ChatBox/ChatBox.jsx
+++ b/src/components/ChatBox/ChatBox.jsx
@@ -50,7 +50,7 @@ const generatePayload = ({
     top_k,
     stream,
     model: {
-      name: model_name,
+      model_name,
       integration_uid,
     }
   },


### PR DESCRIPTION
- fix: change name of model into model_name in prompt predict body