### PR TITLE
fix: if there is name or description, they should be kept when select…

### DIFF
--- a/src/pages/Applications/Components/Tools/ToolDatasource.jsx
+++ b/src/pages/Applications/Components/Tools/ToolDatasource.jsx
@@ -52,13 +52,13 @@ export default function ToolDatasource({
   const onChangeDatasource = useCallback(
     (datasource) => {
       const newToolWithId = updateObjectByPath(editToolDetail, 'settings.datasource_id', datasource.value)
-      const newToolWithName = updateObjectByPath(newToolWithId, 'name', datasource.label)
-      const newToolWithDescription = updateObjectByPath(newToolWithName, 'description', datasource.description)
+      const newToolWithName = name ? newToolWithId : updateObjectByPath(newToolWithId, 'name', datasource.label)
+      const newToolWithDescription = description ? newToolWithName : updateObjectByPath(newToolWithName, 'description', datasource.description)
       setEditToolDetail(newToolWithDescription)
       onChangeTools(newToolWithDescription)
       setIsDirty(true);
     },
-    [editToolDetail, onChangeTools, setEditToolDetail],
+    [description, editToolDetail, name, onChangeTools, setEditToolDetail],
   )
 
   return (

--- a/src/pages/Applications/Components/Tools/ToolPrompt.jsx
+++ b/src/pages/Applications/Components/Tools/ToolPrompt.jsx
@@ -47,12 +47,12 @@ export default function ToolPrompt({
 
   const handlePromptChange = useCallback((value) => {
     const newToolWithId = updateObjectByPath(editToolDetail, 'settings.prompt_id', value.value)
-    const newToolWithName = updateObjectByPath(newToolWithId, 'name', value.label)
-    const newToolWithDescription = updateObjectByPath(newToolWithName, 'description', value.description)
+    const newToolWithName = name ? newToolWithId : updateObjectByPath(newToolWithId, 'name', value.label)
+    const newToolWithDescription = description ? newToolWithName : updateObjectByPath(newToolWithName, 'description', value.description)
     setEditToolDetail(newToolWithDescription)
     onChangeTools(newToolWithDescription)
     setIsDirty(true);
-  }, [editToolDetail, onChangeTools, setEditToolDetail]);
+  }, [description, editToolDetail, name, onChangeTools, setEditToolDetail]);
 
   const handleVersionChange = useCallback((value) => {
     const newTool = {


### PR DESCRIPTION
- fix: if there is name or description, they should be kept when selecting a datasource or prompt to create a tool